### PR TITLE
revert removing numpy import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 import os.path
 from setuptools import setup, Extension
 import platform
+try:
+    import numpy
+except ImportError as e:
+    print("=" * 80)
+    print("You need to install numpy *separately* and *before* installing this package(s).")
+    print("=" * 80)
+    raise e from None
 
 with open(os.path.join(os.path.dirname(__file__), "README.md"), encoding="utf-8") as f:
     long_description = f.read()


### PR DESCRIPTION
Just realized, that numpy is used later on in setup.py and thus, the import is necessary